### PR TITLE
Communicating warnings and errors with the dedicated methods

### DIFF
--- a/install_sdpt3.m
+++ b/install_sdpt3.m
@@ -66,12 +66,12 @@ if ~need_rebuild,
     elseif sum(nfound) < length(targets64),
         fprintf( 'incomplete set found.\n' );
         disp( line );
-        disp( 'Some of the binaries for this platform were found, but some' );
-        disp( 'were missing as well. This may mean your download was corrupt;' );
-        disp( 'consider downloading and unpacking SDPT3 again. Otherwise, to' );
-        disp( 'try rebuilding the MEX files yourself, run this command:' );
-        disp( '    install_sdpt3 -rebuild' );
-        fprintf( '%s\n\n', line );
+        warning(['Some of the binaries for this platform were found, but some', char(10), ...
+                 'were missing as well. This may mean your download was corrupt;', char(10), ...
+                 'consider downloading and unpacking SDPT3 again. Otherwise, to', char(10), ...
+                 'try rebuilding the MEX files yourself, run this command:', char(10), ...
+                 '    install_sdpt3 -rebuild', char(10), ...
+                 line, char(10), char(10)]);
         return;
     else
         fprintf( 'found!\n' );
@@ -156,8 +156,8 @@ end
 
 if ~any(nfound),
     disp( line );
-    disp( 'SDPT3 was not successfully installed.' );
-    disp( 'Please attempt to correct the errors and try again.' );
+    error(['SDPT3 was not successfully installed.', char(10), ...
+    	   'Please attempt to correct the errors and try again.']);
 elseif ~no_path,
     disp( line );
     fprintf( 'Adding SDPT3 to the %s path:\n', prog );


### PR DESCRIPTION
When calling the SDPT3 installation script, only the human-readable text displayed by the script informs the user of whether the installation was successful or not. This is problematic for scripted installations: a failure goes unnoticed.

Here, the standard matlab and octave functions `warning` and `error` are used to display warning and error messages. This improves the user display and raises corresponding exceptions, which can be detected programmatically.