### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Octave mex files
+Solver/Mexfun/*.mex


### PR DESCRIPTION
Octave only has a single extension `.mex` for compiled binaries. Therefore, these files should not be committable to the repository (which is meant to be used on all platforms). It is also important to list these binaries in a `.gitignore` file, because using this code once in Octave will create them and will make the codebase look like it has changed, which is not the case. Therefore these files should be ignored.